### PR TITLE
feat(macos): 添加 macOS 启动脚本并支持 ModelScope 模型源

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+venv
+__pycache__
+outputs/*
+!outputs/.gitkeep
+models/*
+!models/.gitkeep
+voicesamples

--- a/01Setup.macos.sh
+++ b/01Setup.macos.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "========================================"
+echo "Qwen Voice TTS Studio 1.1 - Setup Script (macOS)"
+echo "========================================"
+echo
+
+echo "This script is for macOS (zsh users can run it directly)."
+echo
+
+QWEN_MODEL_SOURCE="${QWEN_MODEL_SOURCE:-hf}"
+echo "Model source env: QWEN_MODEL_SOURCE=${QWEN_MODEL_SOURCE}"
+read -r -p "Model source HuggingFace (H) or ModelScope (M)? [H/M]: " MODEL_SRC
+MODEL_SRC="${MODEL_SRC:-H}"
+MODEL_SRC_UPPER="$(printf "%s" "$MODEL_SRC" | tr '[:lower:]' '[:upper:]')"
+if [[ "$MODEL_SRC_UPPER" == "M" ]]; then
+  QWEN_MODEL_SOURCE="modelscope"
+else
+  QWEN_MODEL_SOURCE="hf"
+fi
+export QWEN_MODEL_SOURCE
+echo "Using model source: ${QWEN_MODEL_SOURCE}"
+echo
+
+choose_python() {
+  local candidates
+  candidates=("python3.12" "python3.11" "python3.10" "python3")
+  local cmd
+  for cmd in "${candidates[@]}"; do
+    if command -v "$cmd" >/dev/null 2>&1; then
+      echo "$cmd"
+      return 0
+    fi
+  done
+  return 1
+}
+
+PY="$(choose_python || true)"
+if [[ -z "${PY}" ]]; then
+  echo "ERROR: python3 not found."
+  echo "Please install Python 3.10+ (3.12 recommended) and re-run."
+  exit 1
+fi
+
+if ! "$PY" - <<'PY_CHECK'
+import sys
+sys.exit(0 if sys.version_info >= (3, 10) else 1)
+PY_CHECK
+then
+  echo "ERROR: $PY is below Python 3.10."
+  echo "Please install Python 3.10+ (3.12 recommended)."
+  exit 1
+fi
+
+echo "Using Python: $PY"
+echo
+
+VENV_PATH="$SCRIPT_DIR/venv"
+if [[ -d "$VENV_PATH" ]]; then
+  read -r -p "venv exists. Reuse (R) or create New (N)? [R/N]: " REUSE
+  REUSE="${REUSE:-R}"
+  REUSE_UPPER="$(printf "%s" "$REUSE" | tr '[:lower:]' '[:upper:]')"
+  if [[ "$REUSE_UPPER" == "N" ]]; then
+    echo "Removing existing virtual environment"
+    rm -rf "$VENV_PATH"
+    echo "Creating virtual environment"
+    "$PY" -m venv "$VENV_PATH"
+  else
+    echo "Using existing virtual environment."
+  fi
+else
+  echo "Creating virtual environment"
+  "$PY" -m venv "$VENV_PATH"
+fi
+
+echo
+# shellcheck disable=SC1091
+source "$VENV_PATH/bin/activate"
+
+python -m pip install --upgrade pip
+
+echo
+echo "Installing PyTorch (pinned compatible set for macOS)"
+python -m pip install --upgrade --force-reinstall \
+  torch==2.8.0 torchvision==0.23.0 torchaudio==2.8.0
+
+echo
+echo "Installing requirements"
+python -m pip install -r "$SCRIPT_DIR/requirements.txt"
+
+if [[ "$QWEN_MODEL_SOURCE" == "modelscope" ]]; then
+  echo
+  echo "Installing modelscope for ModelScope downloads"
+  python -m pip install -U modelscope || {
+    echo
+    echo "WARNING: modelscope install failed."
+    echo "ModelScope download option may fail."
+  }
+fi
+
+echo
+echo "Installing qwen-asr (for Voice ASR tab)"
+python -m pip install -U qwen-asr || {
+  echo
+  echo "WARNING: qwen-asr install failed."
+  echo "Voice ASR tab will prompt manual installation."
+}
+
+echo
+echo "Pinning transformers==4.57.3 (required by qwen-tts)"
+python -m pip install --upgrade --no-deps transformers==4.57.3 || {
+  echo
+  echo "WARNING: Failed to pin transformers to 4.57.3."
+}
+
+echo
+echo "flash-attn is skipped on macOS."
+
+mkdir -p "$SCRIPT_DIR/models"
+
+echo
+read -r -p "Download Qwen3-TTS models now (~10-12GB)? (y/N): " DOWNLOAD_MODELS
+DOWNLOAD_MODELS="${DOWNLOAD_MODELS:-N}"
+DOWNLOAD_MODELS_UPPER="$(printf "%s" "$DOWNLOAD_MODELS" | tr '[:lower:]' '[:upper:]')"
+
+if [[ "$DOWNLOAD_MODELS_UPPER" == "Y" ]]; then
+  echo
+  echo "Downloading models into ./models (source: $QWEN_MODEL_SOURCE) ..."
+  python - <<'PY_DL'
+import os
+
+source = (os.environ.get("QWEN_MODEL_SOURCE") or "hf").strip().lower()
+
+repos = [
+  "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
+  "Qwen/Qwen3-TTS-12Hz-1.7B-Base",
+  "Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign",
+]
+for repo in repos:
+  name = repo.split("/")[-1]
+  local_dir = f"models/{name}"
+  print(f"Downloading: {repo} -> {local_dir}")
+
+  if source in ("ms", "modelscope"):
+    try:
+      from modelscope.hub.snapshot_download import snapshot_download
+    except Exception as e:
+      raise RuntimeError(
+        "ModelScope download selected, but modelscope is unavailable"
+      ) from e
+    try:
+      snapshot_download(
+        model_id=repo,
+        local_dir=local_dir,
+      )
+    except TypeError:
+      snapshot_download(
+        model_id=repo,
+        cache_dir=local_dir,
+      )
+  else:
+    from huggingface_hub import snapshot_download
+    snapshot_download(
+      repo_id=repo,
+      local_dir=local_dir,
+      local_dir_use_symlinks=False,
+    )
+print("Model download step finished.")
+PY_DL
+else
+  echo
+  echo "Skipping model download. Models will be pulled on first use."
+fi
+
+echo
+echo "========================================"
+echo "Setup Complete!"
+echo "========================================"
+echo
+echo "Run: ./02Start.macos.sh"

--- a/02Start.macos.sh
+++ b/02Start.macos.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+if [[ ! -f "$SCRIPT_DIR/venv/bin/activate" ]]; then
+  echo "ERROR: venv not found. Run ./01Setup.macos.sh first."
+  exit 1
+fi
+
+export HF_HOME="$SCRIPT_DIR/models"
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/venv/bin/activate"
+
+ARGS=()
+
+echo
+echo "========================================"
+echo "Qwen Voice TTS Studio 1.1 - Startup (macOS)"
+echo "========================================"
+echo
+
+python --version
+python -c "import torch; \
+print('Torch:', torch.__version__); \
+print('CUDA Available:', torch.cuda.is_available()); \
+print('MPS Available:', getattr(torch.backends, 'mps', None) and torch.backends.mps.is_available())" \
+2>/dev/null || true
+
+echo
+read -r -p "Use in LAN mode (other devices can access)? (y/N): " LAN
+LAN="${LAN:-N}"
+LAN_UPPER="$(printf "%s" "$LAN" | tr '[:lower:]' '[:upper:]')"
+
+if [[ "$LAN_UPPER" == "Y" ]]; then
+  LOCAL_IP="$(python - <<'PY_IP'
+import socket
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+try:
+  s.connect(("8.8.8.8", 80))
+  print(s.getsockname()[0])
+except Exception:
+  print("")
+finally:
+  s.close()
+PY_IP
+)"
+
+  if [[ -n "$LOCAL_IP" ]]; then
+    echo "LAN address: http://${LOCAL_IP}:7860"
+  fi
+
+  read -r -p "Listen IP (default 0.0.0.0): " LISTEN_IP
+  LISTEN_IP="${LISTEN_IP:-0.0.0.0}"
+
+  read -r -p "Port (default 7860): " LISTEN_PORT
+  LISTEN_PORT="${LISTEN_PORT:-7860}"
+
+  if [[ -n "$LOCAL_IP" ]]; then
+    echo "LAN address: http://${LOCAL_IP}:${LISTEN_PORT}"
+  fi
+
+  ARGS+=(--listen "$LISTEN_IP" --port "$LISTEN_PORT")
+fi
+
+echo
+echo "Launch command:"
+if [[ ${#ARGS[@]} -gt 0 ]]; then
+  echo "python $SCRIPT_DIR/qwen_voice_gui.py ${ARGS[*]}"
+else
+  echo "python $SCRIPT_DIR/qwen_voice_gui.py"
+fi
+echo
+
+if [[ ${#ARGS[@]} -gt 0 ]]; then
+  python "$SCRIPT_DIR/qwen_voice_gui.py" "${ARGS[@]}"
+else
+  python "$SCRIPT_DIR/qwen_voice_gui.py"
+fi

--- a/README.md
+++ b/README.md
@@ -63,6 +63,30 @@ Run:
 
 **Not tested on Linux**. Please provide a PR if something breaks.
 
+## Quick Start (macOS)
+
+Recommended for macOS users (including default `zsh` shell):
+
+1. Ensure Python `3.10+` is installed (`3.12` recommended).
+2. Install SoX:
+   - `brew install sox`
+3. Make scripts executable:
+   - `chmod +x 01Setup.macos.sh 02Start.macos.sh`
+4. Run setup:
+   - `./01Setup.macos.sh`
+5. Start app:
+   - `./02Start.macos.sh`
+
+Notes:
+
+- `flash-attn` is skipped on macOS.
+- Render runs on CPU (and can use MPS through PyTorch availability).
+- Models can be downloaded during setup or auto-downloaded on first use.
+- You can choose model source in setup:
+  - HuggingFace (default)
+  - ModelScope (`QWEN_MODEL_SOURCE=modelscope`)
+- ASR model download in UI also follows `QWEN_MODEL_SOURCE`.
+
 ## Features
 
 ### Text-to-Speech

--- a/qwen_voice_gui.py
+++ b/qwen_voice_gui.py
@@ -351,29 +351,58 @@ class QwenVoiceGUI:
 
         return self.get_system_info_markdown()
 
+    def _get_model_source(self) -> str:
+        source = (os.environ.get("QWEN_MODEL_SOURCE") or "hf").strip().lower()
+        if source in ("ms", "modelscope"):
+            return "modelscope"
+        return "hf"
+
+    def _snapshot_download(self, repo_id: str, local_dir: Path):
+        source = self._get_model_source()
+        local_dir_str = str(local_dir)
+
+        if source == "modelscope":
+            from modelscope.hub.snapshot_download import (
+                snapshot_download as ms_snapshot_download,
+            )
+            try:
+                return ms_snapshot_download(
+                    model_id=repo_id,
+                    local_dir=local_dir_str,
+                )
+            except TypeError:
+                return ms_snapshot_download(
+                    model_id=repo_id,
+                    cache_dir=local_dir_str,
+                )
+
+        from huggingface_hub import snapshot_download as hf_snapshot_download
+        return hf_snapshot_download(
+            repo_id=repo_id,
+            local_dir=local_dir_str,
+            local_dir_use_symlinks=False,
+        )
+
     def download_asr_models(self, download_forced_aligner: bool = False):
         try:
-            from huggingface_hub import snapshot_download
-
             self.models_dir.mkdir(exist_ok=True)
             asr_local_dir = self.models_dir / "Qwen3-ASR-1.7B"
-            snapshot_download(
+            self._snapshot_download(
                 repo_id="Qwen/Qwen3-ASR-1.7B",
-                local_dir=str(asr_local_dir),
-                local_dir_use_symlinks=False,
+                local_dir=asr_local_dir,
             )
 
             if download_forced_aligner:
                 aligner_local_dir = self.models_dir / "Qwen3-ForcedAligner-0.6B"
-                snapshot_download(
+                self._snapshot_download(
                     repo_id="Qwen/Qwen3-ForcedAligner-0.6B",
-                    local_dir=str(aligner_local_dir),
-                    local_dir_use_symlinks=False,
+                    local_dir=aligner_local_dir,
                 )
 
             self.asr_model = None
             self.asr_model_id = None
-            return "✓ ASR model(s) downloaded to ./models"
+            source = self._get_model_source()
+            return f"✓ ASR model(s) downloaded to ./models via {source}"
         except Exception as e:
             return f"✗ Error downloading ASR model(s): {str(e)}"
 


### PR DESCRIPTION
- 新增 `01Setup.macos.sh` 和 `02Start.macos.sh` 脚本，为 macOS 用户提供快速安装和启动流程
- 修改 `qwen_voice_gui.py` 以支持通过环境变量 `QWEN_MODEL_SOURCE` 选择从 HuggingFace 或 ModelScope 下载模型
- 更新 README.md 添加 macOS 快速入门指南
- 添加 `.gitignore` 文件以忽略虚拟环境、缓存目录和模型文件
- 添加 `outputs/.gitkeep` 以保留空输出目录

<img width="3456" height="2158" alt="image" src="https://github.com/user-attachments/assets/b654c825-c4ef-4989-8086-8a99f2d2f193" />

```
./02Start.macos.sh

========================================
Qwen Voice TTS Studio 1.1 - Startup (macOS)
========================================

Python 3.12.10
Torch: 2.8.0
CUDA Available: False
MPS Available: True

Use in LAN mode (other devices can access)? (y/N): 

Launch command:
python /Users/mac/dev/NarrativeWaves/Qwen-Voice-TTS-Studio/qwen_voice_gui.py

Render Device: Auto | Device: cpu | Attention: eager | FlashAttn2 Available: False

********
Warning: flash-attn is not installed. Will only run the manual PyTorch version. Please install flash-attn for faster inference.
********
 
* Running on local URL:  http://127.0.0.1:7860
* To create a public link, set `share=True` in `launch()`.
Setting `pad_token_id` to `eos_token_id`:2150 for open-end generation.

```